### PR TITLE
Make Travis run tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,4 @@ node_js:
   - '0.10'
 script:
   - echo "var apiKey=''" > server/api-config.js
+  - npm test

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "mongodb-autoincrement": "^1.0.0",
     "mongoose": "^4.1.1",
     "morgan": "^1.6.1",
-    "q": "^1.4.1"
+    "q": "^1.4.1",
+    "unirest": "^0.4.2"
   },
   "devDependencies": {
     "chai": "^3.2.0",

--- a/test/client/TriviaFactorySpec.js
+++ b/test/client/TriviaFactorySpec.js
@@ -21,7 +21,7 @@ describe('UserController', function() {
 
   it('should set questions from HTTP response', function() {
     var mockQuestions = [{}, {}, {}];
-    $httpBackend.expectGET('/questions').respond(mockQuestions);
+    $httpBackend.expectGET('/api/questions').respond(mockQuestions);
     Questions.getQuestions();
     $httpBackend.flush();
     expect(Questions.questions).to.eql(mockQuestions);


### PR DESCRIPTION
Apparently Travis doesn't perform the default command if you have a 'script' option in the config.
