### PR TITLE
Clean login (fix #74)

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -29,13 +29,14 @@
 
         <h1 class="header-title">Trivia with Friends</h1>
 
-        <ul class="nav nav-tabs" ng-controller="NavigationController">
+        <!-- may need to make this a separate view, or use ngShow -->
+        <!-- <ul class="nav nav-tabs" ng-controller="NavigationController">
           <li ng-class="getClass('home')" role="presentation"><a href="/#/home">Home</a></li>
           <li ng-class="getClass('profile')" role="presentation"><a href="/#/profile">Profile</a></li>
           <li ng-class="getClass('stats')" role="presentation"><a href="/#/stats">Stats</a></li>
           <li ng-class="getClass('trivia')" role="presentation"><a href="/#/trivia">Trivia</a></li>
           <li class="pull-right" role="presentation"><a href="/#/signin">Logout</a></li>
-        </ul>
+        </ul> -->
       </div>
     </div>
 

--- a/client/index.html
+++ b/client/index.html
@@ -30,13 +30,15 @@
         <h1 class="header-title">Trivia with Friends</h1>
 
         <!-- may need to make this a separate view, or use ngShow -->
-        <!-- <ul class="nav nav-tabs" ng-controller="NavigationController">
+        <ul class="nav nav-tabs"
+          ng-controller="NavigationController"
+          ng-show="show()">
           <li ng-class="getClass('home')" role="presentation"><a href="/#/home">Home</a></li>
           <li ng-class="getClass('profile')" role="presentation"><a href="/#/profile">Profile</a></li>
           <li ng-class="getClass('stats')" role="presentation"><a href="/#/stats">Stats</a></li>
           <li ng-class="getClass('trivia')" role="presentation"><a href="/#/trivia">Trivia</a></li>
           <li class="pull-right" role="presentation"><a href="/#/signin">Logout</a></li>
-        </ul> -->
+        </ul>
       </div>
     </div>
 

--- a/client/index.html
+++ b/client/index.html
@@ -29,7 +29,7 @@
 
         <h1 class="header-title">Trivia with Friends</h1>
 
-        <!-- may need to make this a separate view, or use ngShow -->
+        <!-- ng-show here is a hack for hiding on signin and signup -->
         <ul class="nav nav-tabs"
           ng-controller="NavigationController"
           ng-show="show()">

--- a/client/javascript/navigation.js
+++ b/client/javascript/navigation.js
@@ -4,11 +4,21 @@
 
   app.controller('NavigationController', ['$scope', '$location', '$state', function($scope, $location, $state) {
 
+    //for changing active nav tab
     $scope.getClass = function(stateName) {
       if (stateName === $state.current.name) {
         return 'active';
       } else {
         return '';
+      }
+    };
+
+    //hack for hiding nav on signin or signup
+    $scope.show = function() {
+      if($location.$$url === '/signin' || $location.$$url === '/signup') {
+        return false;
+      } else {
+        return true;
       }
     };
 

--- a/client/styles/login.css
+++ b/client/styles/login.css
@@ -1,3 +1,4 @@
+/*this css file is no longer used*/
 @import url("http://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css");
 @import url("http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,700");
 *{margin:0; padding:0}

--- a/client/styles/style.css
+++ b/client/styles/style.css
@@ -69,7 +69,7 @@ body {
 }
 
 /*/signin and /signout css*/
-.signin-margin, .signout-margin {
+.signin-margin, .signup-margin {
   margin: 5px 0;
 }
 

--- a/client/styles/style.css
+++ b/client/styles/style.css
@@ -14,10 +14,10 @@ body {
   margin-bottom: 60px;
 }
 
+/*index header css*/
 .twf-header {
   margin-bottom: 30px;
 }
-
 .header-title {
   margin-bottom: 20px;
 }
@@ -34,7 +34,6 @@ body {
 .stats-btn {
   padding: 30px 20px !important;
 }
-
 /*temp css for the d3 charts in stats view*/
 .stats-chart-view {
   border: 1px solid #ddd;
@@ -67,6 +66,11 @@ body {
   letter-spacing: 1px;
   font-size: 18px;
   font-family:Consolas,Monaco,Lucida Console,Liberation Mono,DejaVu Sans Mono,Bitstream Vera Sans Mono,Courier New, monospace;
+}
+
+/*/signin and /signout css*/
+.signin-margin, .signout-margin {
+  margin: 5px 0;
 }
 
 

--- a/client/views/signin.html
+++ b/client/views/signin.html
@@ -1,27 +1,53 @@
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
-<link rel="stylesheet" type="text/css" href="../styles/login.css" />
-<div class="form" ng-controller="UserController">
-  <div class="header">
-    <h2>Sign In</h2>
-  </div>
-  <div class="login">
-    <form action="">
-      <ul>
-        <li>
-          <span class="un"><i class="fa fa-user"></i></span><input type="text" required class="text" placeholder="User Name Or Email" ng-model="user.username"/>
-        </li>
-        <li>
-          <span class="un"><i class="fa fa-lock"></i></span><input type="password" required class="text" placeholder="User Password" ng-model="user.password"/>
-        </li>
-        <li>
-          <input type="submit" value="LOGIN" ng-click="signin()" class="btn">
-        </li>
-      </ul>
-    </form>
-  </div>
-  <br/>
-  <div class="sign">
-    <div class="need">Need new account ?</div>
-    <div class="up"><a href="/#/signup">Sign Up</a></div>
+<div ng-controller="UserController">
+  <div class="row">
+
+    <!-- wrapper column for signin -->
+    <div class="col-md-8 col-md-offset-2">
+      <div>
+        <h3>Sign In</h3>
+      </div>
+      <!-- name or email input -->
+      <div class="row">
+        <div class="col-md-4 signin-margin">
+          <input type="text"
+            class="form-control input-md"
+            required class="text"
+            placeholder="Username"
+            ng-model="user.username"/>
+        </div>
+      </div>
+      <!-- password input -->
+      <div class="row">
+        <div class="col-md-4 signin-margin">
+          <input type="password"
+            class="form-control input-md"
+            required class="text"
+            placeholder="Password"
+            ng-model="user.password"/>
+        </div>
+      </div>
+      <!-- signin button -->
+      <div class="row">
+        <div class="col-md-4 signin-margin">
+          <input type="submit"
+            class="btn btn-primary"
+            value="Submit"
+            ng-click="signin()"/>
+        </div>
+      </div>
+      <!-- new account option -->
+      <br>
+      <div class="row">
+        <div class="col-md-4">
+          Need new account?
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-md-4">
+          <a href="/#/signup">Sign Up</a>
+        </div>
+      </div>
+    </div>
+
   </div>
 </div>

--- a/client/views/signup.html
+++ b/client/views/signup.html
@@ -1,30 +1,62 @@
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
-<link rel="stylesheet" type="text/css" href="../styles/login.css" />
-<div class="form" ng-controller="UserController">
-  <div class="header">
-    <h2>Sign Up</h2>
-  </div>
-  <div class="login">
-    <form action="">
-      <ul>
-        <li>
-          <span class="un"><i class="fa fa-user"></i></span><input type="text" required class="text" placeholder="User Name Or Email" ng-model="user.username"/>
-        </li>
-        <li>
-          <span class="un"><i class="fa fa-lock"></i></span><input type="password" required class="text" placeholder="User Password" ng-model="user.password"/>
-        </li>
-        <li>
-          <span class="un"><i class="fa fa-lock"></i></span><input type="password" required class="text" placeholder="Confirm Password"/>
-        </li>
-        <li>
-          <input type="submit" value="SIGN UP" ng-click="signup()"class="btn">
-        </li>
-      </ul>
-    </form>
-  </div>
-  <br/>
-  <div class="sign">
-    <div class="need">Already have an account ?</div>
-    <div class="up"><a href="/#/signin">Sign in</a></div>
+<div ng-controller="UserController">
+  <div class="row">
+
+    <!-- wrapper column for signup -->
+    <div class="col-md-8 col-md-offset-2">
+      <div>
+        <h3>Sign Up</h3>
+      </div>
+      <!-- name or email input -->
+      <div class="row">
+        <div class="col-md-4 signup-margin">
+          <input type="text"
+            class="form-control input-md"
+            required class="text"
+            placeholder="Username"
+            ng-model="user.username"/>
+        </div>
+      </div>
+      <!-- password input -->
+      <div class="row">
+        <div class="col-md-4 signup-margin">
+          <input type="password"
+            class="form-control input-md"
+            required class="text"
+            placeholder="Password"
+            ng-model="user.password"/>
+        </div>
+      </div>
+      <!-- confirm password input -->
+      <div class="row">
+        <div class="col-md-4 signup-margin">
+          <input type="password"
+            class="form-control input-md"
+            required class="text"
+            placeholder="Confirm Password"/>
+        </div>
+      </div>
+      <!-- signin button -->
+      <div class="row">
+        <div class="col-md-4 signup-margin">
+          <input type="submit"
+            class="btn btn-primary"
+            value="Submit"
+            ng-click="signup()"/>
+        </div>
+      </div>
+      <!-- new account option -->
+      <br>
+      <div class="row">
+        <div class="col-md-4">
+          Already have an account?
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-md-4">
+          <a href="/#/signin">Sign In</a>
+        </div>
+      </div>
+    </div>
+
   </div>
 </div>


### PR DESCRIPTION
```
cleanup signin
cleanup signup css, html refactor of signin and signup, add hack for hiding nav on signin and signup
add note to index.html
```

/signin and /signup are now in line with the basic bootstrap style of the rest of the site. Functionality should be exactly the same, however, the main nav is now hidden on /signin and /signup. This was achieved through an ng-show hack that's probably not the best, and probably ought to be done with a view instead. Since we only have a few more days to work on this, I think this solution works for now.
